### PR TITLE
Simplify webhook for testing

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,20 +5,8 @@ app = Flask(__name__)
 
 @app.route("/webhook", methods=['POST'])
 def whatsapp_reply():
-    incoming_msg = request.values.get('Body', '').lower()
-    resp = MessagingResponse()
-    msg = resp.message()
-
-    if "hola" in incoming_msg:
-        msg.body("¡Qué onda compa! Bienvenido a *Dogos El Compadre* 🌭🔥 ¿Listo pa' armarte el mejor dogo de tu vida?")
-    elif "menú" in incoming_msg:
-        msg.body("🧾 *Menú:*\n- Dogo Sencillo $45\n- Dogo con Todo $60\n- Dogo de a Metro $400\n¿Le metemos doble salchicha o con eso tienes?")
-    elif "ubicación" in incoming_msg or "dónde están" in incoming_msg:
-        msg.body("📍 Tenemos 3 sucursales:\n1. Jardines\n2. Pueblitos\n3. Puerta Real\nDime cuál quieres y te paso el mapa.")
-    else:
-        msg.body("No caché bien eso, compa. Prueba con: 'menú', 'ubicación' o 'hola' pa' empezar 🔥")
-
-    return str(resp)
+    """Temporary minimal webhook endpoint."""
+    return "ok", 200
 
 if __name__ == "__main__":
     app.run(debug=False, host="0.0.0.0", port=8080)


### PR DESCRIPTION
## Summary
- simplify the `/webhook` endpoint to always return "ok"

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_686175feb3b48323bf1342de44622caf